### PR TITLE
[FIX] Update TileMapGenerator.cs

### DIFF
--- a/Assets/Scripts/Tilemap/TileMapGenerator.cs
+++ b/Assets/Scripts/Tilemap/TileMapGenerator.cs
@@ -30,6 +30,12 @@ public class TileMapGenerator : MonoBehaviour
         DrawMapTiles();
     }
 
+    private void Start()
+    {
+        Transform playerTransform = GameManager.Instance.Player.transform;
+        playerTransform.position = MapGrid.CellToWorld(new Vector3Int(size.x / 2, size.y / 2)) + Vector3.up * 3f;
+    }
+
     void GenerateMap()
     {
         MapHeights = new int[size.x, size.y];


### PR DESCRIPTION
타일맵 크기 줄이면 플레이어가 맵 밖에서 스폰되는 문제

-> 맵 크기에 상관 없이 항상 가운데 스폰되도록 스크립트 수정